### PR TITLE
Fix darwin builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,10 +161,12 @@ build-linux-armhf:
 build-darwin:
   stage:                           build
   <<:                              *collect_artifacts
-  only:                            *releaseable_branches
+  #only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-apple-darwin
     CARGO_HOME:                    "${CI_PROJECT_DIR}/.cargo"
+    CC:                            'clang'
+    CXX:                           'clang'
   script:
     - scripts/gitlab/build-linux.sh
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,12 +161,12 @@ build-linux-armhf:
 build-darwin:
   stage:                           build
   <<:                              *collect_artifacts
-  #only:                            *releaseable_branches
+  only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-apple-darwin
     CARGO_HOME:                    "${CI_PROJECT_DIR}/.cargo"
     CC:                            'clang'
-    CXX:                           'clang'
+    CXX:                           'clang++'
   script:
     - scripts/gitlab/build-linux.sh
   tags:


### PR DESCRIPTION
We now use CC and CXX env variables for specifying compilers. This change adds explicit declarations in the build-darwin gitlab job.