### PR TITLE
[EngineSigner]: don't sign message with only zeroes

### DIFF
--- a/parity/account_utils.rs
+++ b/parity/account_utils.rs
@@ -132,7 +132,13 @@ mod accounts {
 		LocalAccounts(account_provider)
 	}
 
-	pub fn miner_author(spec: &SpecType, dirs: &Directories, account_provider: &Arc<AccountProvider>, engine_signer: Address, passwords: &[Password]) -> Result<Option<ethcore::miner::Author>, String> {
+	pub fn miner_author(
+		spec: &SpecType,
+		dirs: &Directories,
+		account_provider: &Arc<AccountProvider>,
+		engine_signer: Address,
+		passwords: &[Password]
+	) -> Result<Option<ethcore::miner::Author>, String> {
 		use engine::signer::EngineSigner;
 
 		const SECP_TEST_MESSAGE: H256 = H256([1_u8; 32]);
@@ -167,7 +173,6 @@ mod accounts {
 				engine_signer, invalid_reasons, VERIFY_PASSWORD_HINT
 		))
 	}
-
 
 	mod private_tx {
 		use super::*;

--- a/parity/account_utils.rs
+++ b/parity/account_utils.rs
@@ -152,8 +152,9 @@ mod accounts {
 				engine_signer,
 				password.clone(),
 			);
-			if signer.sign(Default::default()).is_ok() {
-				author = Some(::ethcore::miner::Author::Sealer(Box::new(signer)));
+			// NOTE: rust-secp256k1, a Message cannot be all zeroes anymore
+			if signer.sign([1_u8; 32].into()).is_ok() {
+				author = Some(ethcore::miner::Author::Sealer(Box::new(signer)));
 			}
 		}
 		if author.is_none() {

--- a/rpc/src/v1/helpers/engine_signer.rs
+++ b/rpc/src/v1/helpers/engine_signer.rs
@@ -36,16 +36,14 @@ impl EngineSigner {
 
 impl engine::signer::EngineSigner for EngineSigner {
 	fn sign(&self, message: Message) -> Result<Signature, Error> {
-		match self.accounts.sign(self.address, Some(self.password.clone()), message) {
-			Ok(ok) => Ok(ok),
-			Err(_) => Err(Error::InvalidSecretKey),
-		}
+		self.accounts.sign(self.address, Some(self.password.clone()), message).map_err(|e| {
+			Error::Custom(e.to_string())
+		})
 	}
 
 	fn decrypt(&self, auth_data: &[u8], cipher: &[u8]) -> Result<Vec<u8>, Error> {
 		self.accounts.decrypt(self.address, None, auth_data, cipher).map_err(|e| {
-			warn!("Unable to decrypt message: {:?}", e);
-			Error::InvalidMessage
+			Error::Custom(e.to_string())
 		})
 	}
 


### PR DESCRIPTION
Fixes #11521

At startup the `engine_signer(s)` are tested that they can sign `dummy data`, previously only zeroes were signed to check this. After switching to `upstream rust-secp256k1` signing only zeroes doesn't work which this PR fixes.


