### PR TITLE
Remove AuxiliaryData/AuxiliaryRequest

### DIFF
--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -28,7 +28,7 @@ use common_types::{
 		Seal, SealingState, Headers, PendingTransitionStore,
 		params::CommonParams,
 		machine as machine_types,
-		machine::{AuxiliaryData, AuxiliaryRequest},
+		machine::AuxiliaryData,
 	},
 	errors::{EthcoreError as Error, EngineError},
 	snapshot::Snapshotting,
@@ -134,7 +134,7 @@ impl<'a> ConstructedVerifier<'a> {
 /// Results of a query of whether an epoch change occurred at the given block.
 pub enum EpochChange {
 	/// Cannot determine until more data is passed.
-	Unsure(AuxiliaryRequest),
+	Unsure,
 	/// No epoch change.
 	No,
 	/// The epoch will change, with proof.

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -28,9 +28,9 @@ use common_types::{
 		Seal, SealingState, Headers, PendingTransitionStore,
 		params::CommonParams,
 		machine as machine_types,
-		machine::AuxiliaryData,
 	},
 	errors::{EthcoreError as Error, EngineError},
+	receipt::Receipt,
 	snapshot::Snapshotting,
 	transaction::{self, SignedTransaction, UnverifiedTransaction},
 };
@@ -254,7 +254,7 @@ pub trait Engine: Sync + Send {
 	/// Return `Yes` or `No` when the answer is definitively known.
 	///
 	/// Should not interact with state.
-	fn signals_epoch_end<'a>(&self, _header: &Header, _aux: AuxiliaryData<'a>) -> EpochChange {
+	fn signals_epoch_end<'a>(&self, _header: &Header, _receipts: Option<&'a [Receipt]>) -> EpochChange {
 		EpochChange::No
 	}
 

--- a/ethcore/engines/authority-round/src/lib.rs
+++ b/ethcore/engines/authority-round/src/lib.rs
@@ -71,10 +71,11 @@ use common_types::{
 		PendingTransitionStore,
 		Seal,
 		SealingState,
-		machine::{Call, AuxiliaryData},
+		machine::Call,
 	},
 	errors::{BlockError, EthcoreError as Error, EngineError},
 	ids::BlockId,
+	receipt::Receipt,
 	snapshot::Snapshotting,
 	transaction::SignedTransaction,
 };
@@ -1766,11 +1767,11 @@ impl Engine for AuthorityRound {
 			.map(|set_proof| combine_proofs(0, &set_proof, &[]))
 	}
 
-	fn signals_epoch_end(&self, header: &Header, aux: AuxiliaryData) -> engine::EpochChange {
+	fn signals_epoch_end(&self, header: &Header, receipts: Option<&[Receipt]>) -> engine::EpochChange {
 		if self.immediate_transitions { return engine::EpochChange::No }
 
 		let first = header.number() == 0;
-		self.validators.signals_epoch_end(first, header, aux)
+		self.validators.signals_epoch_end(first, header, receipts)
 	}
 
 	fn is_epoch_end_light(

--- a/ethcore/engines/basic-authority/src/lib.rs
+++ b/ethcore/engines/basic-authority/src/lib.rs
@@ -26,9 +26,10 @@ use common_types::{
 		SealingState,
 		Seal,
 		params::CommonParams,
-		machine::{AuxiliaryData, Call},
+		machine::Call,
 	},
 	errors::{EngineError, BlockError, EthcoreError as Error},
+	receipt::Receipt,
 };
 use client_traits::EngineClient;
 use ethereum_types::{H256, H520};
@@ -142,16 +143,16 @@ impl Engine for BasicAuthority {
 	}
 
 	#[cfg(not(any(test, feature = "test-helpers")))]
-	fn signals_epoch_end(&self, _header: &Header, _auxiliary: AuxiliaryData) -> engine::EpochChange {
+	fn signals_epoch_end(&self, _header: &Header, _receipts: Option<&[Receipt]>) -> engine::EpochChange {
 		// don't bother signalling even though a contract might try.
 		engine::EpochChange::No
 	}
 
 	#[cfg(any(test, feature = "test-helpers"))]
-	fn signals_epoch_end(&self, header: &Header, auxiliary: AuxiliaryData) -> engine::EpochChange {
+	fn signals_epoch_end(&self, header: &Header, receipts: Option<&[Receipt]>) -> engine::EpochChange {
 		// in test mode, always signal even though they don't be finalized.
 		let first = header.number() == 0;
-		self.validators.signals_epoch_end(first, header, auxiliary)
+		self.validators.signals_epoch_end(first, header, receipts)
 	}
 
 	fn is_epoch_end(

--- a/ethcore/engines/validator-set/src/contract.rs
+++ b/ethcore/engines/validator-set/src/contract.rs
@@ -30,7 +30,8 @@ use common_types::{
 	ids::BlockId,
 	header::Header,
 	errors::EthcoreError,
-	engines::machine::{Call, AuxiliaryData},
+	engines::machine::Call,
+	receipt::Receipt,
 	transaction,
 };
 
@@ -141,9 +142,9 @@ impl ValidatorSet for ValidatorContract {
 		&self,
 		first: bool,
 		header: &Header,
-		aux: AuxiliaryData,
+		receipts: Option<&[Receipt]>,
 	) -> engine::EpochChange {
-		self.validators.signals_epoch_end(first, header, aux)
+		self.validators.signals_epoch_end(first, header, receipts)
 	}
 
 	fn epoch_set(&self, first: bool, machine: &Machine, number: BlockNumber, proof: &[u8]) -> Result<(SimpleList, Option<H256>), EthcoreError> {

--- a/ethcore/engines/validator-set/src/lib.rs
+++ b/ethcore/engines/validator-set/src/lib.rs
@@ -31,7 +31,8 @@ use common_types::{
 	header::Header,
 	ids::BlockId,
 	errors::EthcoreError,
-	engines::machine::{Call, AuxiliaryData},
+	engines::machine::Call,
+	receipt::Receipt,
 };
 use engine::SystemCall;
 use ethereum_types::{H256, Address};
@@ -144,7 +145,7 @@ pub trait ValidatorSet: Send + Sync + 'static {
 		&self,
 		first: bool,
 		header: &Header,
-		aux: AuxiliaryData,
+		receipts: Option<&[Receipt]>,
 	) -> engine::EpochChange;
 
 	/// Recover the validator set from the given proof, the block number, and

--- a/ethcore/engines/validator-set/src/multi.rs
+++ b/ethcore/engines/validator-set/src/multi.rs
@@ -24,7 +24,8 @@ use common_types::{
 	header::Header,
 	ids::BlockId,
 	errors::EthcoreError,
-	engines::machine::{Call, AuxiliaryData},
+	engines::machine::Call,
+	receipt::Receipt,
 };
 use client_traits::EngineClient;
 use ethereum_types::{H256, Address};
@@ -117,13 +118,13 @@ impl ValidatorSet for Multi {
 		set.is_epoch_end(first, chain_head)
 	}
 
-	fn signals_epoch_end(&self, _first: bool, header: &Header, aux: AuxiliaryData)
+	fn signals_epoch_end(&self, _first: bool, header: &Header, receipts: Option<&[Receipt]>)
 		-> engine::EpochChange
 	{
 		let (set_block, set) = self.correct_set_by_number(header.number());
 		let first = set_block == header.number();
 
-		set.signals_epoch_end(first, header, aux)
+		set.signals_epoch_end(first, header, receipts)
 	}
 
 	fn epoch_set(&self, _first: bool, machine: &Machine, number: BlockNumber, proof: &[u8]) -> Result<(super::SimpleList, Option<H256>), EthcoreError> {

--- a/ethcore/engines/validator-set/src/safe_contract.rs
+++ b/ethcore/engines/validator-set/src/safe_contract.rs
@@ -26,7 +26,7 @@ use common_types::{
 	errors::{EngineError, EthcoreError, BlockError},
 	ids::BlockId,
 	log_entry::LogEntry,
-	engines::machine::{Call, AuxiliaryData},
+	engines::machine::Call,
 	receipt::Receipt,
 	transaction::{self, Action, Transaction},
 };
@@ -438,11 +438,9 @@ impl ValidatorSet for ValidatorSafeContract {
 		None // no immediate transitions to contract.
 	}
 
-	fn signals_epoch_end(&self, first: bool, header: &Header, aux: AuxiliaryData)
+	fn signals_epoch_end(&self, first: bool, header: &Header, receipts: Option<&[Receipt]>)
 		-> engine::EpochChange
 	{
-		let receipts = aux.receipts;
-
 		// transition to the first block of a contract requires finality but has no log event.
 		if first {
 			debug!(target: "engine", "signalling transition to fresh contract.");
@@ -642,7 +640,6 @@ mod tests {
 	use accounts::AccountProvider;
 	use common_types::{
 		ids::BlockId,
-		engines::machine::AuxiliaryRequest,
 		header::Header,
 		log_entry::LogEntry,
 		transaction::{Transaction, Action},

--- a/ethcore/engines/validator-set/src/safe_contract.rs
+++ b/ethcore/engines/validator-set/src/safe_contract.rs
@@ -26,7 +26,7 @@ use common_types::{
 	errors::{EngineError, EthcoreError, BlockError},
 	ids::BlockId,
 	log_entry::LogEntry,
-	engines::machine::{Call, AuxiliaryData, AuxiliaryRequest},
+	engines::machine::{Call, AuxiliaryData},
 	receipt::Receipt,
 	transaction::{self, Action, Transaction},
 };
@@ -462,7 +462,7 @@ impl ValidatorSet for ValidatorSafeContract {
 		trace!(target: "engine", "detected epoch change event bloom");
 
 		match receipts {
-			None => engine::EpochChange::Unsure(AuxiliaryRequest::Receipts),
+			None => engine::EpochChange::Unsure,
 			Some(receipts) => match self.extract_from_event(bloom, header, receipts) {
 				None => engine::EpochChange::No,
 				Some(list) => {
@@ -774,7 +774,7 @@ mod tests {
 		new_header.set_log_bloom(event.bloom());
 
 		match engine.signals_epoch_end(&new_header, Default::default()) {
-			EpochChange::Unsure(AuxiliaryRequest::Receipts) => {},
+			EpochChange::Unsure => {},
 			_ => panic!("Expected bloom to be recognized."),
 		};
 	}

--- a/ethcore/engines/validator-set/src/simple_list.rs
+++ b/ethcore/engines/validator-set/src/simple_list.rs
@@ -21,7 +21,8 @@ use common_types::{
 	ids::BlockId,
 	header::Header,
 	errors::EthcoreError,
-	engines::machine::{Call, AuxiliaryData},
+	engines::machine::Call,
+	receipt::Receipt,
 };
 use ethereum_types::{H256, Address};
 use log::warn;
@@ -89,9 +90,7 @@ impl ValidatorSet for SimpleList {
 		}
 	}
 
-	fn signals_epoch_end(&self, _: bool, _: &Header, _: AuxiliaryData)
-		-> engine::EpochChange
-	{
+	fn signals_epoch_end(&self, _: bool, _: &Header, _: Option<&[Receipt]>) -> engine::EpochChange {
 		engine::EpochChange::No
 	}
 

--- a/ethcore/engines/validator-set/src/test.rs
+++ b/ethcore/engines/validator-set/src/test.rs
@@ -27,7 +27,8 @@ use common_types::{
 	ids::BlockId,
 	header::Header,
 	errors::EthcoreError,
-	engines::machine::{Call, AuxiliaryData},
+	engines::machine::Call,
+	receipt::Receipt,
 };
 use ethereum_types::{H256, Address};
 use machine::Machine;
@@ -94,9 +95,7 @@ impl ValidatorSet for TestSet {
 
 	fn is_epoch_end(&self, _first: bool, _chain_head: &Header) -> Option<Vec<u8>> { None }
 
-	fn signals_epoch_end(&self, _: bool, _: &Header, _: AuxiliaryData)
-		-> engine::EpochChange
-	{
+	fn signals_epoch_end(&self, _: bool, _: &Header, _: Option<&[Receipt]>) -> engine::EpochChange {
 		engine::EpochChange::No
 	}
 

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -474,18 +474,12 @@ impl<T: ChainDataFetcher> Client<T> {
 	}
 
 	fn check_epoch_signal(&self, verified_header: &Header) -> Result<Option<Proof>, T::Error> {
-		use common_types::engines::machine::AuxiliaryData;
-
 		let mut receipts: Option<Vec<_>> = None;
 
 		loop {
 
 			let is_signal = {
-				let auxiliary = AuxiliaryData {
-					receipts: receipts.as_ref().map(|x| &x[..]),
-				};
-
-				self.engine.signals_epoch_end(verified_header, auxiliary)
+				self.engine.signals_epoch_end(verified_header, receipts.as_ref().map(|x| &x[..]))
 			};
 
 			// check with any auxiliary data fetched so far

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -478,12 +478,12 @@ impl<T: ChainDataFetcher> Client<T> {
 
 		loop {
 
-			let is_signal = {
+			let is_transition = {
 				self.engine.signals_epoch_end(verified_header, receipts.as_ref().map(|x| &x[..]))
 			};
 
-			// check with any auxiliary data fetched so far
-			match is_signal {
+			// check if we need to fetch receipts
+			match is_transition {
 				EpochChange::No => return Ok(None),
 				EpochChange::Yes(proof) => return Ok(Some(proof)),
 				EpochChange::Unsure => {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -308,7 +308,7 @@ impl Importer {
 					continue;
 				}
 
-				match self.check_and_lock_block(&bytes, block, client) {
+				match self.check_and_lock_block(block, client) {
 					Ok((closed_block, pending)) => {
 						imported_blocks.push(hash);
 						let transactions_len = closed_block.transactions.len();
@@ -362,7 +362,7 @@ impl Importer {
 		imported
 	}
 
-	fn check_and_lock_block(&self, bytes: &[u8], block: PreverifiedBlock, client: &Client) -> EthcoreResult<(LockedBlock, Option<PendingTransition>)> {
+	fn check_and_lock_block(&self, block: PreverifiedBlock, client: &Client) -> EthcoreResult<(LockedBlock, Option<PendingTransition>)> {
 		let engine = &*self.engine;
 		let header = block.header.clone();
 
@@ -448,7 +448,6 @@ impl Importer {
 
 		let pending = self.check_epoch_end_signal(
 			&header,
-			bytes,
 			&locked_block.receipts,
 			locked_block.state.db(),
 			client
@@ -596,7 +595,6 @@ impl Importer {
 	fn check_epoch_end_signal(
 		&self,
 		header: &Header,
-		block_bytes: &[u8],
 		receipts: &[Receipt],
 		state_db: &StateDB,
 		client: &Client,
@@ -604,10 +602,7 @@ impl Importer {
 		use engine::EpochChange;
 
 		let hash = header.hash();
-		let auxiliary = AuxiliaryData {
-			bytes: Some(block_bytes),
-			receipts: Some(&receipts),
-		};
+		let auxiliary = AuxiliaryData { receipts: Some(&receipts) };
 
 		match self.engine.signals_epoch_end(header, auxiliary) {
 			EpochChange::Yes(proof) => {
@@ -671,7 +666,7 @@ impl Importer {
 				Ok(Some(PendingTransition { proof }))
 			},
 			EpochChange::No => Ok(None),
-			EpochChange::Unsure(_) => {
+			EpochChange::Unsure => {
 				warn!(target: "client", "Detected invalid engine implementation.");
 				warn!(target: "client", "Engine claims to require more block data, but everything provided.");
 				Err(EngineError::InvalidEngine.into())
@@ -2402,7 +2397,6 @@ impl ImportSealedBlock for Client {
 
 			let pending = self.importer.check_epoch_end_signal(
 				&header,
-				&block_bytes,
 				&block.receipts,
 				block.state.db(),
 				self

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -114,7 +114,7 @@ use types::{
 	engines::{
 		epoch::{PendingTransition, Transition as EpochTransition},
 		ForkChoice,
-		machine::{AuxiliaryData, Call as MachineCall},
+		machine::Call as MachineCall,
 		MAX_UNCLE_AGE,
 		SealingState,
 	},
@@ -602,9 +602,7 @@ impl Importer {
 		use engine::EpochChange;
 
 		let hash = header.hash();
-		let auxiliary = AuxiliaryData { receipts: Some(&receipts) };
-
-		match self.engine.signals_epoch_end(header, auxiliary) {
+		match self.engine.signals_epoch_end(header, Some(&receipts)) {
 			EpochChange::Yes(proof) => {
 				use engine::Proof;
 

--- a/ethcore/types/src/engines/machine.rs
+++ b/ethcore/types/src/engines/machine.rs
@@ -29,23 +29,10 @@ use crate::{
 /// Returns the call result and state proof for each call.
 pub type Call<'a> = dyn Fn(Address, Vec<u8>) -> Result<(Vec<u8>, Vec<Vec<u8>>), String> + 'a;
 
-/// Request for auxiliary data of a block.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum AuxiliaryRequest {
-	/// Needs the body.
-	Body,
-	/// Needs the receipts.
-	Receipts,
-	/// Needs both body and receipts.
-	Both,
-}
-
 /// Auxiliary data fetcher for an Ethereum machine. In Ethereum-like machines
 /// there are two kinds of auxiliary data: bodies and receipts.
 #[derive(Default, Clone)]
 pub struct AuxiliaryData<'a> {
-	/// The full block bytes, including the header.
-	pub bytes: Option<&'a [u8]>,
 	/// The block receipts.
 	pub receipts: Option<&'a [receipt::Receipt]>,
 }

--- a/ethcore/types/src/engines/machine.rs
+++ b/ethcore/types/src/engines/machine.rs
@@ -21,22 +21,12 @@ use bytes::Bytes;
 
 use crate::{
 	log_entry::LogEntry,
-	receipt,
 	state_diff::StateDiff,
 };
 
 /// Type alias for a function we can make calls through synchronously.
 /// Returns the call result and state proof for each call.
 pub type Call<'a> = dyn Fn(Address, Vec<u8>) -> Result<(Vec<u8>, Vec<Vec<u8>>), String> + 'a;
-
-/// Auxiliary data fetcher for an Ethereum machine. In Ethereum-like machines
-/// there are two kinds of auxiliary data: bodies and receipts.
-#[derive(Default, Clone)]
-pub struct AuxiliaryData<'a> {
-	/// The block receipts.
-	pub receipts: Option<&'a [receipt::Receipt]>,
-}
-
 
 /// Transaction execution receipt.
 #[derive(Debug, PartialEq, Clone)]


### PR DESCRIPTION
The only `Engine` that uses `AuxiliaryData` is `AuthorityRound` and it only uses `Receipt`. This PR removes both `AuxiliaryData` and `AuxiliaryRequest` types and changes the `Engine` asnd `ValidatorSet` traits to use just `Receipt`.

I am a little worried that I have misunderstood the implications of this, in particular when it comes to the Light client, so careful review of that code would be much appreciated.